### PR TITLE
feat: add asset proxy so v0 web can read slack files

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -44,7 +44,9 @@
         "im:history",
         "mpim:history",
         "assistant:write",
-        "reactions:write"
+        "reactions:write",
+        "files:read",
+        "files:write"
       ]
     }
   },

--- a/server/lib/assets/utils.ts
+++ b/server/lib/assets/utils.ts
@@ -1,0 +1,91 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const ASSET_SIGNING_SECRET = process.env.ASSET_SIGNING_SECRET;
+const DEFAULT_EXPIRY_HOURS = 24;
+
+export interface SignedUrlOptions {
+  expiryHours?: number;
+  chatId?: string;
+}
+
+export function generateSignedAssetUrl(
+  baseUrl: string,
+  slackFileUrl: string,
+  options: SignedUrlOptions = {},
+): string {
+  const { expiryHours = DEFAULT_EXPIRY_HOURS, chatId } = options;
+
+  // Calculate expiration timestamp
+  const expiresAt = Math.floor(Date.now() / 1000) + expiryHours * 60 * 60;
+
+  // Create signature payload
+  const payload = [slackFileUrl, expiresAt.toString(), chatId || ""].join(":");
+
+  // Generate HMAC signature
+  const signature = createHmac("sha256", ASSET_SIGNING_SECRET)
+    .update(payload)
+    .digest("hex");
+
+  // Build signed URL
+  const params = new URLSearchParams({
+    sig: signature,
+    exp: expiresAt.toString(),
+  });
+
+  if (chatId) {
+    params.set("chat", chatId);
+  }
+
+  return `${baseUrl}/assets/${encodeURIComponent(slackFileUrl)}?${params.toString()}`;
+}
+
+export interface ValidationResult {
+  isValid: boolean;
+  error?: string;
+  chatId?: string;
+}
+
+export function validateSignedUrl(
+  slackFileUrl: string,
+  signature: string,
+  expiresAt: string,
+  chatId?: string,
+): ValidationResult {
+  // Check if signature and expiry are provided
+  if (!signature || !expiresAt) {
+    return { isValid: false, error: "Missing signature or expiration" };
+  }
+
+  // Check if URL has expired
+  const now = Math.floor(Date.now() / 1000);
+  const expiry = parseInt(expiresAt, 10);
+
+  if (Number.isNaN(expiry) || now > expiry) {
+    return { isValid: false, error: "URL has expired" };
+  }
+
+  // Recreate the signature payload
+  const payload = [slackFileUrl, expiresAt, chatId || ""].join(":");
+
+  // Generate expected signature
+  const expectedSignature = createHmac("sha256", ASSET_SIGNING_SECRET)
+    .update(payload)
+    .digest("hex");
+
+  // Compare signatures using constant-time comparison to prevent timing attacks
+  const isValidSignature =
+    signature.length === expectedSignature.length &&
+    timingSafeEqual(
+      Buffer.from(signature, "hex"),
+      Buffer.from(expectedSignature, "hex")
+    );
+
+  if (!isValidSignature) {
+    return { isValid: false, error: "Invalid signature" };
+  }
+
+  return {
+    isValid: true,
+    chatId: chatId || undefined,
+  };
+}

--- a/server/routes/assets/[path].get.ts
+++ b/server/routes/assets/[path].get.ts
@@ -1,0 +1,75 @@
+import {
+  defineEventHandler,
+  getRequestHost,
+  getRequestIP,
+  sendProxy,
+} from "h3";
+import { app } from "~/app";
+import { validateSignedUrl } from "~/lib/assets/utils";
+
+export default defineEventHandler(async (event) => {
+  const encodedUrl = getRouterParam(event, "path");
+
+  if (!encodedUrl) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Asset URL is required",
+    });
+  }
+
+  try {
+    // Decode the URL that was passed as the path parameter
+    const fileUrl = decodeURIComponent(encodedUrl);
+
+    // Validate that this is a Slack file URL
+    if (!fileUrl.match(/^https:\/\/(files\.)?slack\.com\//)) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: "Invalid Slack file URL",
+      });
+    }
+
+    // Extract query parameters for signature validation
+    const query = getQuery(event);
+    const signature = query.sig as string;
+    const expiresAt = query.exp as string;
+    const chatId = query.chat as string;
+
+    // Validate the signed URL
+    const validation = validateSignedUrl(fileUrl, signature, expiresAt, chatId);
+
+    if (!validation.isValid) {
+      app.logger.warn(`Invalid asset request: ${validation.error}`, {
+        fileUrl,
+        clientIp: getRequestIP(event),
+        userAgent: getRequestHeader(event, "user-agent"),
+        host: getRequestHost(event),
+      });
+
+      throw createError({
+        statusCode: 403,
+        statusMessage: validation.error || "Access denied",
+      });
+    }
+
+    // Use sendProxy for reliable streaming with authentication
+    return sendProxy(event, fileUrl, {
+      headers: {
+        Authorization: `Bearer ${process.env.SLACK_BOT_TOKEN}`,
+      },
+      sendStream: true,
+      streamRequest: true,
+    });
+  } catch (error) {
+    app.logger.error("Error fetching Slack asset:", error);
+
+    if (error.statusCode) {
+      throw error;
+    }
+
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Failed to fetch asset from Slack",
+    });
+  }
+});


### PR DESCRIPTION
This pull request introduces secure, signed asset URL support for accessing Slack files, ensuring that only authorized requests can fetch files via our server. It adds HMAC-based URL signing and validation utilities, a new asset proxy route that validates and streams Slack files, and updates the app manifest to request the necessary Slack file permissions.

**Slack file access and security improvements:**

* Added `generateSignedAssetUrl` and `validateSignedUrl` functions in `server/lib/assets/utils.ts` to create and verify HMAC-signed URLs for Slack file access, including expiry and optional chat scoping.
* Introduced a new route handler in `server/routes/assets/[path].get.ts` that validates incoming asset requests using the signature, checks for expiration, and securely proxies files from Slack using the bot token. ([server/routes/assets/[path].get.tsR1-R75](diffhunk://#diff-f6c7b8d06fc469e475b0864ce6a1e20fbade2efe684b040ce4aea66a1a27416aR1-R75))

**Permissions and manifest updates:**

* Updated `manifest.json` to request `files:read` and `files:write` scopes, enabling the app to access and manage files in Slack.