### PR TITLE
fix: update thread only if channel and thread

### DIFF
--- a/server/lib/slack/utils.ts
+++ b/server/lib/slack/utils.ts
@@ -47,6 +47,11 @@ export const updateAgentStatus = async ({
   thread_ts: string;
   status: string;
 }) => {
+  if (!channel || !thread_ts) {
+    app.logger.warn("updateAgentStatus skipped: missing channel/thread_ts");
+    return;
+  }
+
   try {
     await app.client.assistant.threads.setStatus({
       channel_id: channel,


### PR DESCRIPTION
This pull request introduces a small but important safeguard to the `updateAgentStatus` function to prevent errors when required parameters are missing.

* Added a check to ensure both `channel` and `thread_ts` are provided before attempting to update agent status, logging a warning and skipping the operation if either is missing.